### PR TITLE
New rule to detect wrong character syntax

### DIFF
--- a/src/kibit/rules/misc.clj
+++ b/src/kibit/rules/misc.clj
@@ -99,6 +99,14 @@
           (logic/project [form]
             (logic/== sbst (concat form (list arg)))))]))])
 
+  ;; Wrong character syntax
+  (let [sym (logic/lvar)]
+    [#(logic/all
+       (logic/== % sym)
+       (logic/pred sym symbol?)
+       (logic/pred sym (fn [sym] (.matches (name sym) ".'"))))
+     #(logic/project [sym]
+       (logic/== % (first (name sym))))])
 
   ;; Other
   [(not (some ?pred ?coll)) (not-any? ?pred ?coll)])

--- a/test/kibit/test/misc.clj
+++ b/test/kibit/test/misc.clj
@@ -29,4 +29,5 @@
     '(form arg) '(->> arg form)
     '(:form arg) '(->> arg :form)
     '(first-of-form rest-of-form arg) '(->> arg (first-of-form rest-of-form))
-    '(not-any? pred coll) '(not (some pred coll))))
+    '(not-any? pred coll) '(not (some pred coll))
+    \a 'a'))


### PR DESCRIPTION
Detects when character literals are written as __'a'__ instead of __\a__.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jonase/kibit/63)
<!-- Reviewable:end -->
