### PR TITLE
Enable emacs' next-error function with kibit hits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Put the following into your `~/.emacs`:
 ;; Teach compile the syntax of the kibit output
 (require 'compile)
 (add-to-list 'compilation-error-regexp-alist-alist
-	     '(kibit "At \\([^:]+\\):\\([[:digit:]]+\\):" 1 2 nil 0))
+	     '(kibit "At \\([^:]+\\):\\([[:digit:]]+\\):" 1 2 nil 2))
 (add-to-list 'compilation-error-regexp-alist 'kibit)
 
 ;; A convenient command to run "lein kibit" in the project to which


### PR DESCRIPTION
For next-error (bound by default to C-x `) to automatically take me to
the location where Kibit was reporting an issue in the *compilation*
buffer, I needed to change the alist it was using to parse the reports
so that they are marked as errors, not just information.