### PR TITLE
Output exception details to STDERR

### DIFF
--- a/src/kibit/driver.clj
+++ b/src/kibit/driver.clj
@@ -40,8 +40,9 @@
                                                                     cli-reporter)
                                         :rules (or rules all-rules))
                             (catch Exception e
-                              (println "Check failed -- skipping rest of file")
-                              (println (.getMessage e)))))
+                              (binding [*out* *err*]
+                                (println "Check failed -- skipping rest of file")
+                                (println (.getMessage e))))))
             source-files)))
 
 (defn external-run


### PR DESCRIPTION
When an exception occurs when running a check, output debugging details
about the exception to STDERR.

The Code Climate kitbit engine wraps kibit and emits issues in JSON
for each check on STDOUT. Any unexpected content on STDOUT causes the
engine run to fail as debugging information is expected on STDERR.
This small patch moves the output of debugging information to to
STDERR.