### PR TITLE
suggest mapcat instead of flatten + map

### DIFF
--- a/src/kibit/rules/misc.clj
+++ b/src/kibit/rules/misc.clj
@@ -10,17 +10,18 @@
     (if (neg? idx)
       (Character/isUpperCase (first sym))
       (Character/isUpperCase (nth sym (inc idx))))))
-  
+
 
 (defrules rules
   ;; clojure.string
   [(apply str (interpose ?x ?y)) (clojure.string/join ?x ?y)]
   [(apply str (reverse ?x)) (clojure.string/reverse ?x)]
-  [(apply str ?x) (clojure.string/join ?x)] 
+  [(apply str ?x) (clojure.string/join ?x)]
 
   ;; mapcat
   [(apply concat (apply map ?x ?y)) (mapcat ?x ?y)]
   [(apply concat (map ?x . ?y)) (mapcat ?x . ?y)]
+  [(flatten (map ?x . ?y)) (mapcat ?x . ?y)]
 
   ;; filter
   [(filter (complement ?pred) ?coll) (remove ?pred ?coll)]
@@ -49,7 +50,7 @@
 
   ;; Java stuff
   [(.toString ?x) (str ?x)]
-  
+
   (let [obj (logic/lvar)
         method (logic/lvar)
         args (logic/lvar)]
@@ -73,7 +74,7 @@
               args (if s? (rest static-method) args)
               static-method (if s? (first static-method) static-method)]
           (logic/== % `(~(symbol (str klass "/" static-method)) ~@args))))])
-  
+
   ;; Threading
   (let [form (logic/lvar)
         arg (logic/lvar)]
@@ -121,7 +122,7 @@
   (map (fn [x] (Integer/parseInteger x))
        [1 2 3])
 
-  
+
   (map (fn [m] (:key m)) [some maps])
   (map (fn [m] (:key m alt)) [a b c])
 
@@ -138,5 +139,5 @@
   (->> x f) ;; (f x)
   (->> x (f a b)) ;; (f a b x)
   (->> x (f)) ;; (f x)
-  
+
   )

--- a/test/kibit/test/misc.clj
+++ b/test/kibit/test/misc.clj
@@ -20,6 +20,7 @@
     '(clojure.string/reverse x) '(apply str (reverse x))
     '(mapcat x y) '(apply concat (apply map x y))
     '(mapcat x y) '(apply concat (map x y))
+    '(mapcat x y) '(flatten (map x y))
     '(remove pred coll) '(filter (complement pred) coll)
     '(remove empty? coll) '(filter seq coll)
     '(remove pred coll) '(filter #(not (pred %)) coll)


### PR DESCRIPTION
I'm kind of new to clojure so I'm not 100% sure this rule makes sense, but I've been using `(flatten (map ...` frequently until I found about `mapcat` which looks it like does exactly that.