### PR TITLE
Automatically apply suggestions to source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 ### Additions
+* Automatic replacement of suggestions (`--replace` and `--interactive` cli arguments)
 * Enabled Emacs' next error function to go to next Kibit suggestion. See the updated code in the README for the change.
 
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ If you want to know how the Kibit rule system works there are some slides availa
 If `lein kibit` returns any suggestions to forms then it's exit code will be 1. Otherwise it will exit 0. This can be useful to add in a build step for automated testing.
 
 
-    $lein kibit
+    $ lein kibit
     ... suggestions follow
 
-    $echo $?
+    $ echo $?
     1
 
 ## Automatically rerunning when files change
@@ -56,7 +56,7 @@ You can use [lein-auto](https://github.com/weavejester/lein-auto) to run kibit a
 lein-auto's README for installation instructions. Note that this will run kibit over all of your files, not just the
 ones that have changed.
 
-    $lein auto kibit
+    $ lein auto kibit
     auto> Files changed: project.clj, [...]
     auto> Running: lein kibit
     ... suggestions follow
@@ -65,6 +65,37 @@ ones that have changed.
     auto> Running: lein kibit
     ... suggestions follow
     auto> Failed.
+
+## Automatically replacing suggestions in source file
+
+You can have kibit automatically apply suggestions to your source files.
+
+Given a file:
+
+```clojure
+(ns example)
+
+(+ 1 a)
+```
+
+    $ lein kibit --replace
+
+will rewrite the file as:
+
+```clojure
+(ns example)
+
+(+ 1 a)
+```
+
+Replacement can also be run interactively:
+
+    $ lein kibit --replace --interactive
+     Would you like to replace
+       (+ 1 a)
+      with
+       (inc a)
+     in example.clj:3? [yes/no]
 
 ## Reporters
 

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
             :comments "Contact if any questions"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/core.logic "0.8.10"]
-                 [org.clojure/tools.cli "0.3.1"]]
+                 [org.clojure/tools.cli "0.3.1"]
+                 [rewrite-clj "0.4.12"]]
   :profiles {:dev {:dependencies [[lein-marginalia "0.8.0"]]
                    :resource-paths ["test/resources"]}}
   :deploy-repositories [["releases" :clojars]]

--- a/src/kibit/replace.clj
+++ b/src/kibit/replace.clj
@@ -63,6 +63,8 @@
   [expr reporter kw-opts]
   (if-let [check-map (apply check/check-expr
                             (rewrite.zip/sexpr expr)
+                            :resolution
+                            :subform
                             kw-opts)]
     (if (reporter (assoc check-map
                          :line

--- a/src/kibit/replace.clj
+++ b/src/kibit/replace.clj
@@ -1,0 +1,113 @@
+(ns kibit.replace
+  (:require [clojure.string :as str]
+            [clojure.java.io :as io]
+            [rewrite-clj.zip :as rewrite.zip]
+            [rewrite-clj.node :as rewrite.node]
+            [kibit.check :as check]
+            [kibit.reporters :as reporters]))
+
+(defn- prompt
+  "Create a yes/no prompt using the given message.
+
+  From `leiningen.ancient.console`."
+  [& msg]
+  (let [msg (str (str/join msg) " [yes/no] ")]
+    (locking *out*
+      (loop [i 0]
+        (when (= (mod i 4) 2)
+          (println "*** please type in one of 'yes'/'y' or 'no'/'n' ***"))
+        (print msg)
+        (flush)
+        (let [r (or (read-line) "")
+              r (.toLowerCase ^String r)]
+          (case r
+            ("yes" "y") true
+            ("no" "n")  false
+            (recur (inc i))))))))
+
+(defn- report-or-prompt
+  ""
+  [file interactive? {:keys [line expr alt]}]
+  (if interactive?
+    (prompt (with-out-str
+              (println "Would you like to replace")
+              (reporters/pprint-code expr)
+              (println " with")
+              (reporters/pprint-code alt)
+              (print (format "in %s:%s?" file line))))
+    (do
+      (println "Replacing")
+      (reporters/pprint-code expr)
+      (println " with")
+      (reporters/pprint-code alt)
+      (println (format "in %s:%s" file line))
+
+      true)))
+
+(def ^:private expr? (comp not rewrite.node/printable-only? rewrite.zip/node))
+
+(defn- map-zipper
+  "Apply `f` to all code forms in `zipper0`"
+  [f zipper0]
+  (let [zipper (if (expr? zipper0)
+                 (rewrite.zip/postwalk zipper0
+                                       expr?
+                                       f)
+                 zipper0)]
+    (if (rewrite.zip/rightmost? zipper)
+      zipper
+      (recur f (rewrite.zip/right zipper)))))
+
+(defn- replace-expr*
+  ""
+  [expr reporter kw-opts]
+  (if-let [check-map (apply check/check-expr
+                            (rewrite.zip/sexpr expr)
+                            kw-opts)]
+    (if (reporter (assoc check-map
+                         :line
+                         (-> expr rewrite.zip/node meta :row)))
+      (recur (rewrite.zip/edit expr
+                               (fn -replace-expr [sexpr]
+                                 (:alt check-map)))
+             reporter
+             kw-opts)
+      expr)
+    expr))
+
+(defn replace-expr
+  "Apply any suggestions to `expr`.
+
+  `expr`    - Code form to check and replace in
+  `kw-opts` - any valid option for `check/check-expr`, as well as:
+              - `:file` current filename
+              - `:interactive` prompt for confirmation before replacement or not
+
+  Returns a string of the replaced form"
+  [expr & kw-opts]
+  (let [options (apply hash-map kw-opts)]
+    ;; TODO use (:reporter options) to determine format?
+    (replace-expr* expr
+                   (partial report-or-prompt
+                            (:file options)
+                            (:interactive options))
+                   kw-opts)))
+
+(defn replace-file
+  "Apply any suggestions to `file`.
+
+  `file`    - File to check and replace in
+  `kw-opts` - any valid option for `check/check-expr`, as well as:
+              - `:interactive` prompt for confirmation before replacement or not
+
+  Modifies `file`, returns `nil`"
+  [file & kw-opts]
+  (->> (slurp file)
+       rewrite.zip/of-string
+       (map-zipper (fn -replace-expr [node]
+                     (apply replace-expr
+                            node
+                            :file (str file)
+                            kw-opts)))
+       rewrite.zip/root-string
+       (spit file)))

--- a/src/kibit/replace.clj
+++ b/src/kibit/replace.clj
@@ -71,7 +71,11 @@
                          (-> zipper rewrite.zip/node meta :row)))
       (recur (rewrite.zip/edit zipper
                                (fn -replace-zipper [sexpr]
-                                 (:alt check-map)))
+                                 (vary-meta (:alt check-map)
+                                            (fn -remove-loc [m]
+                                              (dissoc m
+                                                      :line
+                                                      :column)))))
              reporter
              kw-opts)
       zipper)

--- a/test/kibit/test/replace.clj
+++ b/test/kibit/test/replace.clj
@@ -1,0 +1,29 @@
+(ns kibit.test.replace
+  (:require [kibit.check :as check]
+            [kibit.rules :as rules]
+            [kibit.replace :as replace])
+  (:use [clojure.test])
+  (:import java.io.File))
+
+(deftest replace-file-are
+  (are [expected-form test-form]
+      (= expected-form
+         (let [file (doto (File/createTempFile "replace-file" ".clj")
+                      (.deleteOnExit)
+                      (spit test-form))]
+           (with-out-str (replace/replace-file file))
+           (slurp file)))
+
+    "(inc a)"
+    "(+ 1 a)"
+
+    "(ns replace-file)
+
+     (defn \"Documentation\" ^{:my-meta 1} [a]
+       ;; a comment
+       (inc a))"
+    "(ns replace-file)
+
+     (defn \"Documentation\" ^{:my-meta 1} [a]
+       ;; a comment
+       (+ 1 a))"))

--- a/test/kibit/test/replace.clj
+++ b/test/kibit/test/replace.clj
@@ -3,7 +3,30 @@
             [kibit.rules :as rules]
             [kibit.replace :as replace])
   (:use [clojure.test])
-  (:import java.io.File))
+  (:import java.io.File
+           java.io.StringWriter))
+
+(defmacro discard-output
+  "Like `with-out-str`, but discards was was written to *out*"
+  [& body]
+  `(binding [*out* (StringWriter.)]
+     ~@body))
+
+(deftest replace-expr-are
+  (are [expected-form test-form]
+      (= expected-form
+         (discard-output
+          (replace/replace-expr test-form)))
+
+    '(inc a)
+    '(+ 1 a)
+
+    '(defn "Documentation" ^{:my-meta 1} [a]
+       ;; a comment
+       (inc a))
+    '(defn "Documentation" ^{:my-meta 1} [a]
+       ;; a comment
+       (+ 1 a))))
 
 (deftest replace-file-are
   (are [expected-form test-form]
@@ -11,7 +34,7 @@
          (let [file (doto (File/createTempFile "replace-file" ".clj")
                       (.deleteOnExit)
                       (spit test-form))]
-           (with-out-str (replace/replace-file file))
+           (discard-output (replace/replace-file file))
            (slurp file)))
 
     "(inc a)"


### PR DESCRIPTION
Introduces `--replace` and `--interactive` cli arguments to automatically replace suggestions in source files.
- The performance isn't great in comparison to regular `lein kibit` (about a 5x
  slowdown):
  
  ```
  ➜ clojure git:(master)
  ✗ time lein kibit src/clj/clojure/core.clj > /dev/null lein kibit
  src/clj/clojure/core.clj > /dev/null 143.17s user 1.56s system 114% cpu
  2:06.60 total ➜ clojure git:(master) ✗ time lein kibit --replace
  src/clj/clojure/core.clj > /dev/null lein kibit --replace
  src/clj/clojure/core.clj > /dev/null 661.69s user 3.82s system 105% cpu
  10:28.20 total ➜ clojure git:(master) ✗ git diff --stat | cat
  src/clj/clojure/core.clj | 741 ++++++++++++++++++++++-------------------------
  ```
  
  Let me know if you notice potential performance issues in this PR
  that I missed, but I think the main slowdown is due to `rewrite-clj`'s parser
  compared to the one `kibit.check` is using
- There are some improvements that I want to make to `kibit.reporters` (#157) which is why the
  "reporters" for replace appear in the `kibit.replace` namespace
