### PR TITLE
catch stackoverflow errors, log failing files

### DIFF
--- a/src/kibit/driver.clj
+++ b/src/kibit/driver.clj
@@ -39,10 +39,10 @@
                                         :reporter (name-to-reporter (:reporter options)
                                                                     cli-reporter)
                                         :rules (or rules all-rules))
-                            (catch Exception e
+                            (catch Throwable e
                               (binding [*out* *err*]
-                                (println "Check failed -- skipping rest of file")
-                                (println (.getMessage e))))))
+                                (println (str "At " (.getPath file) ":0:\nCheck failed -- skipping rest of file"))
+                                (println (str "Exception message: " (pr-str (.getMessage e))))))))
             source-files)))
 
 (defn external-run


### PR DESCRIPTION
Sometimes kibit fails on processing file and it aborts whole process with uncaught StackOverflowError. This change catches that kind of errors and logs failing files in compatible message format, so user can view it using emacs kibit extension.
