### PR TITLE
not empty is not equivalent to seq

### DIFF
--- a/src/kibit/rules/collections.clj
+++ b/src/kibit/rules/collections.clj
@@ -13,10 +13,6 @@
   [(assoc ?coll ?key (?fn (get ?coll ?key) . ?args)) (update-in ?coll [?key] ?fn . ?args)]
   [(update-in ?coll ?keys assoc ?val) (assoc-in ?coll ?keys ?val)]
 
-  ;; empty?
-  [(not (empty? ?x)) (seq ?x)]
-  [(when-not (empty? ?x) . ?y) (when (seq ?x) . ?y)]
-
   ;; set
   [(into #{} ?coll) (set ?coll)]
 

--- a/test/kibit/test/collections.clj
+++ b/test/kibit/test/collections.clj
@@ -5,9 +5,6 @@
 (deftest collections-are
   (are [expected-alt-form test-form]
        (= expected-alt-form (:alt (kibit/check-expr test-form)))
-    '(seq a) '(not (empty? a))
-    '(when (seq a) b) '(when-not (empty? a) b)
-    '(when (seq a) b) '(when (not (empty? a)) b)
     '(vector a) '(conj [] a)
     '(vector a b) '(conj [] a b)
     '(vec coll) '(into [] coll)


### PR DESCRIPTION
``` clojure
(not (empty? x))
```

is in the general case not equivalent to

``` clojure
(seq x)
```

without a strong test checking it would have introduced a bug in my code.

Furthermore it is semantically easier to understand `(not (empty? x))` instead of `(seq x)`.

So we should get rid of this simplification as it is false.
