### PR TITLE
Update core.logic dep to avoid 1.9 spec exception

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :distribution :repo
             :comments "Contact if any questions"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.logic "0.8.10"]
+                 [org.clojure/core.logic "0.8.11"]
                  [org.clojure/tools.cli "0.3.5"]]
   :profiles {:dev {:dependencies [[lein-marginalia "0.9.0"]]
                    :resource-paths ["test/resources"]}}


### PR DESCRIPTION
Compiling core.logic 0.8.10 with the latest beta of Clojure 1.9, produces a clojure.spec exception. The problem was fixed by Alex Miller in this commit: https://github.com/clojure/core.logic/commit/29917372ef066c42ca362e3a94f68d620ddd1b56, and core.logic was bumped to 0.8.11 with no other changes.