### PR TITLE
Monkeypatch core.logic to make sets work

### DIFF
--- a/src/kibit/monkeypatch.clj
+++ b/src/kibit/monkeypatch.clj
@@ -1,0 +1,40 @@
+(ns kibit.monkeypatch
+  "Various helpers providing a with-monkeypatches form which wraps"
+  (:require [clojure.core.logic :as c.c.l])
+  (:import [clojure.lang
+            Var
+            IPersistentSet]
+           [clojure.core.logic.protocols
+            ITreeTerm]))
+
+(defn ^:pivate tree-term? [x]
+  (and (or (coll? x)
+           (instance? ITreeTerm x))
+       (not (instance? IPersistentSet x))))
+
+(def kibit-redefs
+  {#'c.c.l/tree-term? tree-term?})
+
+(defmacro with-monkeypatches
+  "Builds a try/finally which captures Var bindings (and ^:macro tags) comming in, creates new Var
+  bindings within the try and in the finally restores the original bindings. This allows users to
+  establish stack-local patched contexts."
+  {:style/indent [1]}
+  [redefs & forms]
+  (let [redefs            (eval redefs)
+        original-bindings (into {}
+                                (for [k (keys redefs)]
+                                  [k (gensym)]))]
+    `(let [~@(for [[k v] original-bindings
+                   f     [v `(deref ~k)]]
+               f)]
+       (try ~@(for [[k v] redefs]
+                `(do (.bindRoot ~k ~v)
+                     ~(if (.isMacro ^Var k)
+                        `(.setMacro ~k))))
+            ~@forms
+            (finally
+              ~@(for [[k v] redefs]
+                  `(do (.bindRoot ~k ~(get original-bindings k))
+                       ~(if (.isMacro ^Var k)
+                          `(.setMacro ~k)))))))))

--- a/test/kibit/test/driver.clj
+++ b/test/kibit/test/driver.clj
@@ -13,5 +13,9 @@
 (deftest find-clojure-sources-are
   (is (= [(io/file "test/resources/first.clj")
           (io/file "test/resources/second.cljx")
+          (io/file "test/resources/sets.clj")
           (io/file "test/resources/third.cljs")]
          (driver/find-clojure-sources-in-dir (io/file "test/resources")))))
+
+(deftest test-set-file
+  (is (driver/run ["test/resources/sets.clj"] nil)))

--- a/test/resources/sets.clj
+++ b/test/resources/sets.clj
@@ -1,0 +1,4 @@
+(ns resources.sets)
+
+(defn killit [coll]
+  (not-any? #{"string1" "string2"} (map ffirst coll)))


### PR DESCRIPTION
This changeset tweaks the driver implementation to use `Var.setRoot` in a `try/finally` to establish an execution scope with a patched implementation of `tree-term?` that won't allow infinite recursion on sets.

Criticisms of this patch:

1. Blatant monkey patching
2. Assumes that kibit is only ever used via the driver interface, never as a library.

More of an effort could have been made to keep the test impact minimal, but that can be cleaned up.

Fixes #78 