### PR TITLE
Add run! rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ pom.xml.asc
 /autodoc
 /docs
 
+# IntelliJ IDEA
+.idea
+*.iml

--- a/kibit/src/kibit/rules/collections.clj
+++ b/kibit/src/kibit/rules/collections.clj
@@ -21,6 +21,5 @@
   [(into #{} ?coll) (set ?coll)]
 
   [(take ?n (repeatedly ?coll)) (repeatedly ?n ?coll)]
-  [(doall (map ?fn ?coll)) (run! ?fn ?coll)]
-  [(doall (mapv ?fn ?coll)) (run! ?fn ?coll)])
+  [(doall (map ?fn ?coll)) (run! ?fn ?coll)])
 

--- a/kibit/src/kibit/rules/collections.clj
+++ b/kibit/src/kibit/rules/collections.clj
@@ -21,5 +21,4 @@
   [(into #{} ?coll) (set ?coll)]
 
   [(take ?n (repeatedly ?coll)) (repeatedly ?n ?coll)]
-  [(doall (map ?fn ?coll)) (run! ?fn ?coll)])
-
+  [(dorun (map ?fn ?coll)) (run! ?fn ?coll)])

--- a/kibit/src/kibit/rules/collections.clj
+++ b/kibit/src/kibit/rules/collections.clj
@@ -20,5 +20,7 @@
   ;; set
   [(into #{} ?coll) (set ?coll)]
 
-  [(take ?n (repeatedly ?coll)) (repeatedly ?n ?coll)])
+  [(take ?n (repeatedly ?coll)) (repeatedly ?n ?coll)]
+  [(doall (map ?fn ?coll)) (run! ?fn ?coll)]
+  [(doall (mapv ?fn ?coll)) (run! ?fn ?coll)])
 

--- a/kibit/test/kibit/test/collections.clj
+++ b/kibit/test/kibit/test/collections.clj
@@ -23,7 +23,7 @@
     '(update-in coll [k] f a b c) '(assoc coll k (f (get coll k) a b c))
     '(assoc-in coll [k1 k2] v) '(update-in coll [k1 k2] assoc v)
     '(repeatedly 10 (constantly :foo)) '(take 10 (repeatedly (constantly :foo)))
-    '(run! f coll) '(doall (map f coll))
+    '(run! f coll) '(dorun (map f coll))
 
     ;; some wrong simplifications happened in the past:
     nil '(assoc coll k (assoc (coll k0) k1 a))

--- a/kibit/test/kibit/test/collections.clj
+++ b/kibit/test/kibit/test/collections.clj
@@ -23,6 +23,8 @@
     '(update-in coll [k] f a b c) '(assoc coll k (f (get coll k) a b c))
     '(assoc-in coll [k1 k2] v) '(update-in coll [k1 k2] assoc v)
     '(repeatedly 10 (constantly :foo)) '(take 10 (repeatedly (constantly :foo)))
+    '(run! f coll) '(doall (map f coll))
+    '(run! f coll) '(doall (mapv f coll))
 
     ;; some wrong simplifications happened in the past:
     nil '(assoc coll k (assoc (coll k0) k1 a))

--- a/kibit/test/kibit/test/collections.clj
+++ b/kibit/test/kibit/test/collections.clj
@@ -24,7 +24,6 @@
     '(assoc-in coll [k1 k2] v) '(update-in coll [k1 k2] assoc v)
     '(repeatedly 10 (constantly :foo)) '(take 10 (repeatedly (constantly :foo)))
     '(run! f coll) '(doall (map f coll))
-    '(run! f coll) '(doall (mapv f coll))
 
     ;; some wrong simplifications happened in the past:
     nil '(assoc coll k (assoc (coll k0) k1 a))


### PR DESCRIPTION
Added rules for [run!](https://clojuredocs.org/clojure.core/run!) so that
```clojure
(doall (map f coll))
```
is replaced by
```clojure
(run! f coll)
```
Got the idea from https://stuartsierra.com/2015/08/25/clojure-donts-lazy-effects
Run is more concise and makes it clear that the iteration produces side-effects