### PR TITLE
Really test #78

### DIFF
--- a/kibit/test/kibit/test/collections.clj
+++ b/kibit/test/kibit/test/collections.clj
@@ -28,9 +28,4 @@
     ;; some wrong simplifications happened in the past:
     nil '(assoc coll k (assoc (coll k0) k1 a))
     nil '(assoc coll k (assoc (get coll k0) k1 a))
-    nil '(assoc coll k (assoc (k0 coll) k1 a))
-    nil '#{#{}
-           #{#{}}
-           #{#{#{}}}
-           #{#{#{#{}}}}
-           #{#{#{#{#{}}}}}}))
+    nil '(assoc coll k (assoc (k0 coll) k1 a))))

--- a/kibit/test/resources/sets.clj
+++ b/kibit/test/resources/sets.clj
@@ -1,4 +1,12 @@
 (ns resources.sets)
 
+(def Z_4
+  "This just shows that #78"
+  #{#{}
+    #{#{}}
+    #{#{#{}}}
+    #{#{#{#{}}}}
+    #{#{#{#{#{}}}}}})
+
 (defn killit [coll]
   (not-any? #{"string1" "string2"} (map ffirst coll)))


### PR DESCRIPTION
show that we can source analyze the failing nested  `#{}` form, rather than simply showing that we can analyze a single form without utilizing the kibit driver where the monkeypatches are applied.