### PR TITLE
Migrate to tools.reader to solve aliased keyword pains

### DIFF
--- a/kibit/project.clj
+++ b/kibit/project.clj
@@ -8,7 +8,8 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.logic "0.8.11"]
                  [org.clojure/tools.cli "0.3.5"]
-                 [rewrite-clj "0.4.12"]]
+                 [rewrite-clj "0.4.12"]
+                 [org.clojure/tools.reader "1.0.2"]]
   :profiles {:dev {:dependencies [[lein-marginalia "0.9.0"]]
                    :resource-paths ["test/resources"]}}
   :deploy-repositories [["releases" :clojars]

--- a/kibit/src/kibit/check/reader.clj
+++ b/kibit/src/kibit/check/reader.clj
@@ -1,0 +1,111 @@
+(ns kibit.check.reader
+  (:require [clojure.tools.reader :as reader])
+  (:import [clojure.lang LineNumberingPushbackReader]))
+
+;; Preprocessing
+;; -------------
+;; Alias pre-processing
+
+;; It is necessary at read time to maintain a small amount of state
+;; about the contents of the stream read so far to enable the proper
+;; reading of aliased keywords. Clojure accomplishes this during
+;; `(:require ...)` because evaluation and compilation is interlaced
+;; with reading so as to establish aliases in a namespace as it is
+;; being loaded. To do this statically we need to maintain a temporary
+;; table of namespaces to aliases. Additionally, we cannot simply use
+;; a map of aliases as it is possible to switch namespaces mid-file
+;; and get one stream to effectively hop between two namespaces.
+
+
+(defmulti derive-aliases first :default 'ns)
+
+(defn derive-alias-from-dep
+  [[dep & rest]]
+  (let [seq? (seq rest)
+        index (and seq?
+                   (first (keep-indexed #(if (= :as %2) %1)
+                                        rest)))
+        alias (and index
+                   (nth rest (inc index)))]
+    (when alias
+      [alias dep])))
+
+(defn unquote-if-quoted
+  [form]
+  (if (and (seq? form)
+           (= 'quote (first form)))
+    (second form)
+    form))
+
+(defmethod derive-aliases 'ns
+  [[_ _ns & ns-asserts]]
+  (->> ns-asserts
+       (group-by first)
+       (reduce (fn [m [k v]]
+                 (assoc m k (mapcat rest v)))
+               {})
+       ((juxt :require :require-macros))
+       (apply concat)
+       (map derive-alias-from-dep)
+       (remove nil?)
+       (into {})))
+
+(defmethod derive-aliases 'require
+  [[_ & deps]]
+  (->> deps
+       (map (comp derive-alias-from-dep unquote-if-quoted))
+       (remove nil?)
+       (into {})))
+
+;; Reading source files
+;; --------------------
+;; ### Extracting forms
+
+;; `read-file` is intended to be used with a Clojure source file,
+;; read in by Clojure's LineNumberingPushbackReader *(LNPR)*. Expressions are
+;; extracted using the clojure reader (ala `read`), and line numbers
+;; are added as `:line` metadata to the forms (via LNPR).
+
+(defn- careful-refer
+  "Refers into the provided namespace all public vars from clojure.core
+except for those that would clobber any existing interned vars in that
+namespace.  This is needed to ensure that symbols read within syntax-quote
+end up being fully-qualified to clojure.core as appropriate, and only
+to *ns* if they're not available there.  AFAICT, this will work for all
+symbols in syntax-quote except for those referring to vars that are referred
+into the namespace."
+  [ns]
+  (binding [*ns* ns]
+    (refer 'clojure.core :exclude (or (keys (ns-interns ns)) ())))
+  ns)
+
+(def eof (Object.))
+
+(defn trace [v] (println v) v)
+
+(defn read-file
+  "Generate a lazy sequence of top level forms from a
+   LineNumberingPushbackReader"
+  [^LineNumberingPushbackReader r init-ns]
+  (let [ns (careful-refer (create-ns init-ns))
+        do-read (fn do-read [ns alias-map]
+                  (lazy-seq
+                   (let [form (binding [*ns* ns
+                                        reader/*alias-map* (merge (ns-aliases ns)
+                                                                  (alias-map ns))]
+                                (reader/read r false eof))
+                         [ns? new-ns k] (when (sequential? form) form)
+                         new-ns (unquote-if-quoted new-ns)
+                         ns (if (and (symbol? new-ns)
+                                     (#{'ns 'in-ns} ns?))
+                              (careful-refer (create-ns new-ns))
+                              ns)
+                         alias-map (if (#{'require 'ns} ns?)
+                                     (update alias-map ns
+                                             merge
+                                             (derive-aliases form))
+                                     alias-map)]
+                     (when-not (= form eof)
+                       (cons form (do-read ns alias-map))))))]
+    (do-read ns {ns {}})))
+

--- a/kibit/test/kibit/test/check_reader.clj
+++ b/kibit/test/kibit/test/check_reader.clj
@@ -1,0 +1,14 @@
+(ns kibit.test.check-reader
+  (:require [kibit.check.reader :as reader])
+  (:use [clojure.test]))
+
+(deftest derive-aliases-test
+  (are [expected-alias-map ns-form]
+      (= expected-alias-map (reader/derive-aliases ns-form))
+      '{foo foo.bar.baz} '(ns derive.test.one
+                            (:require [foo.bar.baz :as foo]))
+      '{foo foo.bar.baz
+        foom foo.bar.baz.macros} '(ns derive.test.one
+                                    (:require [foo.bar.baz :as foo])
+                                    (:require-macros [foo.bar.baz.macros :as foom]))
+      '{str clojure.string} '(require (quote [clojure.string :as str]))))

--- a/kibit/test/kibit/test/driver.clj
+++ b/kibit/test/kibit/test/driver.clj
@@ -1,7 +1,8 @@
 (ns kibit.test.driver
   (:require [kibit.driver :as driver]
             [clojure.test :refer :all]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io])
+  (:import (java.io ByteArrayOutputStream PrintWriter)))
 
 (deftest clojure-file-are
   (are [expected file] (= expected (driver/clojure-file? (io/file file)))
@@ -12,6 +13,7 @@
 
 (deftest find-clojure-sources-are
   (is (= [(io/file "test/resources/first.clj")
+          (io/file "test/resources/keywords.clj")
           (io/file "test/resources/second.cljx")
           (io/file "test/resources/sets.clj")
           (io/file "test/resources/third.cljs")]
@@ -19,3 +21,11 @@
 
 (deftest test-set-file
   (is (driver/run ["test/resources/sets.clj"] nil)))
+
+(deftest test-keywords-file
+  (let [test-buf (ByteArrayOutputStream.)
+        test-err (PrintWriter. test-buf)]
+    (binding [*err* test-err]
+      (driver/run ["test/resources/keywords.clj"] nil))
+    (is (zero? (.size test-buf))
+        (format "Test err buffer contained '%s'" (.toString test-buf)))))

--- a/kibit/test/resources/keywords.clj
+++ b/kibit/test/resources/keywords.clj
@@ -1,0 +1,20 @@
+(ns resources.keywords
+  (:require [clojure.java.io :as io]))
+
+(defn aliased-keyword-access
+  [x]
+  (::io/some-fake-key x))
+
+(ns resources.non-conforming)
+
+(require '[clojure.string :as str])
+
+(defn using-a-different-keyword-alias-in-different-ns
+  [z]
+  (::str/another-fake-key z))
+
+(in-ns 'resources.keywords)
+
+(defn flipped-back-aliases-still-there
+  [y]
+  (::io/last-fake-key y))


### PR DESCRIPTION
Fixes #14 

- Takes dependency on clojure.tools.reader 1.0.2, lein deps :tree remains
   clean for this project.clj
- Introduces kibit.check.reader namespace for managing all our reading
  concerns.
- Migrate reading fns from kibit.check to kibit.check.reader
- Add alias analyzing & util fns to kibit.check.reader
- Add tests for analyzing fns to kibit.check-reader
- Add keywords.clj test resource which includes several iterations of
   alias backflips to make sure that some simple edge cases for
   keyword reading are handled.

Notes:

I tested this across our internal projects which we want to integrate kibit into our CI process on, where we use a lot of namespace aliased keywords (largely due to spec)

We had previously had a blind spot past any aliased keyword in any file, so using this branch surfaced many more kibit improvements in our code base. Additionally, kibit ran to completion successfully in both projects.

We still have a blind spot in that some of our ClojureScript code contains `#js {:foo :bar}` tagged literals that are not properly handled in either clojure.core/read or clojure.tools.reader/read.

Love to hear feedback if people can play with this branch on their own source trees and vet it for correctness.