### PR TITLE
Fixed issues: #207 unit tests fails on win due to line breaks, #206 driver/run returns simplify maps with no :file

### DIFF
--- a/kibit/src/kibit/check.clj
+++ b/kibit/src/kibit/check.clj
@@ -197,8 +197,9 @@
     (with-open [reader (io/reader source-file)]
       (with-bindings default-data-reader-binding
         (doall (map (fn [simplify-map]
-                      (do (reporter (assoc simplify-map :file source-file))
-                          simplify-map))
+                      (let [file-simplify (assoc simplify-map :file source-file)]
+                        (reporter file-simplify)
+                        file-simplify))
                     (check-reader reader
                                   :rules rules
                                   :guard guard

--- a/kibit/test/kibit/test/reporters.clj
+++ b/kibit/test/kibit/test/reporters.clj
@@ -10,8 +10,8 @@
 
 (deftest plain
   (are [check-map result]
-       (= (reported-lines (with-out-str (reporters/cli-reporter check-map)))
-          result)
+       (= (with-out-str (reporters/cli-reporter check-map))
+          (string/join (System/getProperty "line.separator") result))
        {:file "some/file.clj"
         :line 30
         :expr '(+ x 1)
@@ -19,11 +19,12 @@
                         "Consider using:"
                         "  (inc x)"
                         "instead of:"
-                        "  (+ x 1)"]))
+                        "  (+ x 1)"
+                               "" ""]))
 (deftest gfm
   (are [check-map result]
-       (= (reported-lines (with-out-str (reporters/gfm-reporter check-map)))
-          result)
+       (= (with-out-str (reporters/gfm-reporter check-map))
+          (string/join (System/getProperty "line.separator") result))
        {:file "some/file.clj"
         :line 30
         :expr '(+ x 1)
@@ -36,4 +37,5 @@
                         "instead of:"
                         "```clojure"
                         "  (+ x 1)"
-                        "```"]))
+                        "```"
+                               "" ""]))

--- a/kibit/test/kibit/test/reporters.clj
+++ b/kibit/test/kibit/test/reporters.clj
@@ -3,10 +3,15 @@
             [clojure.string :as string]
             [clojure.test :refer :all]))
 
+(defn- reported-lines [reporting]
+  (->> (clojure.string/split reporting #"\n")
+       (mapv #(clojure.string/replace % "\r" ""))
+       (filterv (complement clojure.string/blank?))))
+
 (deftest plain
   (are [check-map result]
-       (= (with-out-str (reporters/cli-reporter check-map))
-          (string/join "\n" result))
+       (= (reported-lines (with-out-str (reporters/cli-reporter check-map)))
+          result)
        {:file "some/file.clj"
         :line 30
         :expr '(+ x 1)
@@ -14,12 +19,11 @@
                         "Consider using:"
                         "  (inc x)"
                         "instead of:"
-                        "  (+ x 1)"
-                        "" ""]))
+                        "  (+ x 1)"]))
 (deftest gfm
   (are [check-map result]
-       (= (with-out-str (reporters/gfm-reporter check-map))
-          (string/join "\n" result))
+       (= (reported-lines (with-out-str (reporters/gfm-reporter check-map)))
+          result)
        {:file "some/file.clj"
         :line 30
         :expr '(+ x 1)
@@ -32,5 +36,4 @@
                         "instead of:"
                         "```clojure"
                         "  (+ x 1)"
-                        "```"
-                        "" ""]))
+                        "```"]))


### PR DESCRIPTION
- driver/run was returning simplify maps without :file component present in map. Because of that  results from driver/run were not enough informative from perspective of kibit consumers.
- all tests are passing on win. They were not passing because of println and newline producing \r\n on win while on Linux it is just \n