### PR TITLE
Added a file path into an error message while reading a file fixes #405

### DIFF
--- a/kibit/src/kibit/driver.clj
+++ b/kibit/src/kibit/driver.clj
@@ -53,9 +53,13 @@
                                                                   cli-reporter)
                                       :rules (or rules all-rules))
                           (catch Exception e
-                            (binding [*out* *err*]
-                              (println "Check failed -- skipping rest of file")
-                              (println (.getMessage e))))))
+                            (let [e-info (ex-data e)]
+                              (binding [*out* *err*]
+                                (println (format "Check failed -- skipping rest of file (%s:%s:%s)"
+                                                 (.getPath file)
+                                                 (:line e-info)
+                                                 (:column e-info)))
+                                (println (.getMessage e)))))))
           source-files))
 
 (defn run [source-paths rules & args]


### PR DESCRIPTION
Hi,

I've added a file name into an error message and I think it'd be helpful.

![screen shot 2018-03-01 at 16 45 50](https://user-images.githubusercontent.com/585068/36854144-84b119d4-1d70-11e8-96c9-9daf0a7699b8.png)
