### PR TITLE
Implement a solution for Issue #202

### DIFF
--- a/kibit/src/kibit/check/reader.clj
+++ b/kibit/src/kibit/check/reader.clj
@@ -84,10 +84,7 @@
   (->> deps
        (mapcat #(deps-from-libspec nil (unquote-if-quoted %) nil))
        (remove (comp nil? :alias meta))
-       (into {} (map (fn [dep]
-                       (println (type (-> dep meta :alias)))
-                       (println (type dep))
-                       [(-> dep meta :alias) dep])))))
+       (into {} (map (fn [dep] [(-> dep meta :alias) dep])))))
 
 (defmethod derive-aliases 'ns
   [[_ _ns & ns-asserts]]

--- a/kibit/test/kibit/test/check_reader.clj
+++ b/kibit/test/kibit/test/check_reader.clj
@@ -12,4 +12,5 @@
                                     (:require [foo.bar.baz :as foo])
                                     (:require-macros [foo.bar.baz.macros :as foom]))
       '{str clojure.string} '(require (quote [clojure.string :as str]))
-      '{pprint clojure.pprint} '(alias 'pprint 'clojure.pprint)))
+      '{pprint clojure.pprint} '(alias 'pprint 'clojure.pprint)
+      '{string clojure.string} '(require (quote [clojure [string :as string]]))))

--- a/kibit/test/kibit/test/check_reader.clj
+++ b/kibit/test/kibit/test/check_reader.clj
@@ -13,4 +13,35 @@
                                     (:require-macros [foo.bar.baz.macros :as foom]))
       '{str clojure.string} '(require (quote [clojure.string :as str]))
       '{pprint clojure.pprint} '(alias 'pprint 'clojure.pprint)
-      '{string clojure.string} '(require (quote [clojure [string :as string]]))))
+      '{string clojure.string} '(require (quote [clojure [string :as string]]))
+      '{kibit-check     kibit.check
+        kibit-replace   kibit.replace
+        kibit-reporters kibit.reporters
+        kibit-rules     kibit.rules
+        foo-bar-war     foo.bar.war
+        foo-baz-waz     foo.baz.waz} '(ns derive.test.one
+                                        (:require [kibit
+                                                   [check :as kibit-check]
+                                                   [replace :as kibit-replace]
+                                                   [reporters :as kibit-reporters]
+                                                   [rules :as kibit-rules]]
+                                                  [foo
+                                                   [bar
+                                                    [war :as foo-bar-war]]
+                                                   [baz
+                                                    [waz :as foo-baz-waz]]]))
+      '{kibit-check     kibit.check
+        kibit-replace   kibit.replace
+        kibit-reporters kibit.reporters
+        kibit-rules     kibit.rules
+        foo-bar-war     foo.bar.war
+        foo-baz-waz     foo.baz.waz} '(require (quote [kibit
+                                                       [check :as kibit-check]
+                                                       [replace :as kibit-replace]
+                                                       [reporters :as kibit-reporters]
+                                                       [rules :as kibit-rules]])
+                                               [foo
+                                                [bar
+                                                 [war :as foo-bar-war]]
+                                                [baz
+                                                 [waz :as foo-baz-waz]]])))


### PR DESCRIPTION
This pull request updates the check reader to address https://github.com/jonase/kibit/issues/202.

As noted in the comments, I used [clojure.tools.namespace.parse][1] as
a basis for recovering dependencies, and added a way to collect the
alias values. Created the `derive-aliases-from-deps` function to
create the alias-map format, and then updated `derive-aliases`
implementations to use it.

[1]: https://github.com/clojure/tools.namespace