### PR TITLE
Fix unambiguous misrenderings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you want to know how the Kibit rule system works there are some slides availa
 
 ## Exit codes
 
-If `lein kibit` returns any suggestions to forms then it's exit code will be 1. Otherwise it will exit 0. This can be useful to add in a build step for automated testing.
+If `lein kibit` returns any suggestions to forms then its exit code will be 1. Otherwise it will exit 0. This can be useful to add in a build step for automated testing.
 
 
     $ lein kibit

--- a/kibit/src/kibit/monkeypatch.clj
+++ b/kibit/src/kibit/monkeypatch.clj
@@ -7,7 +7,7 @@
            [clojure.core.logic.protocols
             ITreeTerm]))
 
-(defn ^:pivate tree-term? [x]
+(defn- tree-term? [x]
   (and (or (coll? x)
            (instance? ITreeTerm x))
        (not (instance? IPersistentSet x))))

--- a/kibit/src/kibit/rules.clj
+++ b/kibit/src/kibit/rules.clj
@@ -22,7 +22,7 @@
 ;; * a pattern expression (e.g. `(+ ?x 1)`)
 ;; * a substitution expression (e.g. `(inc ?x)`
 ;;
-;; These rules are used in the unifcation process to generate suggested
+;; These rules are used in the unification process to generate suggested
 ;; code alternatives.  For more information see:
 ;; [core](#jonase.kibit.core) namespace
 

--- a/kibit/test/kibit/test/replace.clj
+++ b/kibit/test/kibit/test/replace.clj
@@ -7,7 +7,7 @@
            java.io.StringWriter))
 
 (defmacro discard-output
-  "Like `with-out-str`, but discards was was written to *out*"
+  "Like `with-out-str`, but discards what was written to *out*"
   [& body]
   `(binding [*out* (StringWriter.)]
      ~@body))


### PR DESCRIPTION
1) ‘defn-‘ replaces ‘defn ^:pivate’ (<- function in question not called from any other namespace)
2) ‘unification’ replaces ‘unfication’
3) ‘what was written’ replaces ‘was was written’
4) ‘its’ replaces ‘it’s’ in possessive usage

I say unambiguous, but of course there's always multiple perspectives. Easy to break apart or change

Opted for single commit because these changes would be easy to move somewhere else and personally am averse to making commits as small as the ones for making each change individually would be. 

Could certainly see a case for rolling the `defn` change seperately from the doc changes though. 