### PR TITLE
Docstring fixes

### DIFF
--- a/kibit/src/kibit/driver.clj
+++ b/kibit/src/kibit/driver.clj
@@ -67,7 +67,7 @@
 
   Paths is expected to be a sequence of io.File objects.
 
-  Rules is either a collection of rules or nil. If Rules is nil, all of kibit's checkers are used.
+  Rules is either a collection of rules or nil. If rules is nil, all of kibit's checkers are used.
 
   Optionally accepts a :reporter keyword argument, defaulting to \"text\"
   If :replace is provided in options, suggested replacements will be performed automatically."

--- a/kibit/src/kibit/replace.clj
+++ b/kibit/src/kibit/replace.clj
@@ -95,7 +95,7 @@
 (defn replace-expr
   "Apply any suggestions to `expr`.
 
-  `expr`    - Code form to check and replace in
+  `expr`    - Code form to check and replace
   `kw-opts` - any valid option for `check/check-expr`, as well as:
               - `:file` current filename
               - `:interactive` prompt for confirmation before replacement or not


### PR DESCRIPTION
From the commits:

_'Rules'->'rules' in docstring mid-sentence_

Might recommend further changing to `rules` and its ilk throughout
docstring and codebase to conform with style guide for docstring params.

_'replace in'->'replace' for expr replacement_

It is my fallible understanding that for `kibit.replace/replace-expr`,
the return value is the entire expression.

Leaving aside the discussion that `replace-file` might perhaps be more
optimally rendered as `replace-file!`—and `replace-expr` as
`convert-expr` or similar—what seems clear is that the entire
expression is being operated on and returned.

The replacement operation is not being done only in part. Therefore
terminal preposition `in` misses the mark