### PR TITLE
Allows tools to also use the end of a range besides just the start

### DIFF
--- a/kibit/src/kibit/check.clj
+++ b/kibit/src/kibit/check.clj
@@ -67,10 +67,12 @@
   "Construct the canonical simplify-map
   given an expression and a simplified expression."
   [expr simplified-expr]
-  {:expr   expr
-   :line   (-> expr meta :line)
-   :column (-> expr meta :column)
-   :alt    simplified-expr})
+  {:expr       expr
+   :line       (-> expr meta :line)
+   :column     (-> expr meta :column)
+   :end-line   (-> expr meta :end-line)
+   :end-column (-> expr meta :end-column)
+   :alt        simplified-expr})
 
 ;; ### Guarding the check
 


### PR DESCRIPTION
I'm writing an editor plugin that will allow replacing of Kibit suggestions as you type, one by one. In order to do that, I need to tell the editor what range (start line/col to end line/col) can be replaced. Kibit internally has that information, but not in a way that I can access it from the API (unless I missed something of course). 

This pull request exposes the `:end-line` and `:end-column` meta so that I can use it in my editor plugin.

(Note that I'm suing `identity` as a reporter so that I get the data structure for further processing in my plugin.)

I would be super-greatful if this can be merged and deployed, so that I don't have to publish my own fork of Kibit, which I'd rather avoid. Many thanks!