### PR TITLE
Add (more) type hints.

### DIFF
--- a/kibit/deps.edn
+++ b/kibit/deps.edn
@@ -1,0 +1,4 @@
+{:deps {org.clojure/core.logic {:mvn/version "0.8.11"}
+        org.clojure/tools.cli {:mvn/version "0.3.5"}
+        org.clojure/tools.reader {:mvn/version "1.0.2"}
+        rewrite-clj {:mvn/version "0.4.12"}}}

--- a/kibit/src/kibit/driver.clj
+++ b/kibit/src/kibit/driver.clj
@@ -23,13 +23,13 @@
 (defn ends-with?
   "Returns true if the java.io.File ends in any of the strings in coll"
   [file coll]
-  (some #(.endsWith (.getName file) %) coll))
+  (some #(.endsWith (.getName ^File file) %) coll))
 
 (defn clojure-file?
   "Returns true if the java.io.File represents a Clojure source file.
   Extensions taken from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml"
   [file]
-  (and (.isFile file)
+  (and (.isFile ^File file)
        (ends-with? file [".clj" ".cl2" ".cljc" ".cljs" ".cljscm" ".cljx" ".hic" ".hl"])))
 
 (defn find-clojure-sources-in-dir
@@ -56,7 +56,7 @@
                             (let [e-info (ex-data e)]
                               (binding [*out* *err*]
                                 (println (format "Check failed -- skipping rest of file (%s:%s:%s)"
-                                                 (.getPath file)
+                                                 (.getPath ^File file)
                                                  (:line e-info)
                                                  (:column e-info)))
                                 (println (.getMessage e)))))))


### PR DESCRIPTION
I'm playing around with graalvm to compile a native version of kibit. This is needed to make it happy.

I added a deps.edn so that kibit can be used in another project's deps.edn via :local/root. If a new release is in the works, this could easily be omitted.